### PR TITLE
Add per-service eventing setup

### DIFF
--- a/src/Customer/GoingGreen.Customer.API/Eventing/EventingExtensions.cs
+++ b/src/Customer/GoingGreen.Customer.API/Eventing/EventingExtensions.cs
@@ -1,0 +1,52 @@
+using Azure.Messaging.ServiceBus;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Customer.API;
+
+public static class EventingExtensions
+{
+    public static IHostApplicationBuilder AddEventing(this IHostApplicationBuilder builder)
+    {
+        var configuration = builder.Configuration;
+        var pg = configuration.GetConnectionString("Postgres") ?? configuration["POSTGRES_CONNECTION_STRING"];
+        builder.Services.AddMarten(opts =>
+        {
+            opts.Connection(pg);
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.All);
+        }).UseLightweightSessions().UseEventStore();
+
+        var sb = configuration.GetConnectionString("ServiceBus") ?? configuration["SERVICEBUS_CONNECTION_STRING"];
+        if (!string.IsNullOrWhiteSpace(sb))
+        {
+            builder.Services.AddSingleton(new ServiceBusClient(sb));
+            builder.Services.AddSingleton<IEventPublisher, ServiceBusEventPublisher>();
+        }
+
+        return builder;
+    }
+}
+
+public interface IEventPublisher
+{
+    Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default);
+}
+
+public class ServiceBusEventPublisher : IEventPublisher
+{
+    private readonly ServiceBusClient _client;
+
+    public ServiceBusEventPublisher(ServiceBusClient client)
+    {
+        _client = client;
+    }
+
+    public async Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default)
+    {
+        var sender = _client.CreateSender(typeof(T).Name);
+        var body = System.Text.Json.JsonSerializer.Serialize(@event);
+        await sender.SendMessageAsync(new ServiceBusMessage(body), cancellationToken);
+    }
+}

--- a/src/Customer/GoingGreen.Customer.API/Eventing/Events.cs
+++ b/src/Customer/GoingGreen.Customer.API/Eventing/Events.cs
@@ -1,0 +1,5 @@
+namespace Customer.API;
+
+public record QuoteAdjustmentNotified(Guid AssessmentId, decimal AdjustedQuote);
+public record CustomerAcceptedFinalQuote(Guid AssessmentId);
+public record CustomerRejectedFinalQuote(Guid AssessmentId, string Reason);

--- a/src/Customer/GoingGreen.Customer.API/GoingGreen.Customer.API.csproj
+++ b/src/Customer/GoingGreen.Customer.API/GoingGreen.Customer.API.csproj
@@ -6,9 +6,11 @@
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4"/>
-    </ItemGroup>
+  <ItemGroup>
+          <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+          <PackageReference Include="Marten" Version="7.5.0" />
+          <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
+  </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\Common\GoingGreen.ServiceDefaults\GoingGreen.ServiceDefaults.csproj" />

--- a/src/Customer/GoingGreen.Customer.API/Program.cs
+++ b/src/Customer/GoingGreen.Customer.API/Program.cs
@@ -1,7 +1,10 @@
+using Customer.API;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
+builder.AddEventing();
 
 // Add services to the container.
 builder.Services.AddProblemDetails();

--- a/src/Customer/GoingGreen.Customer.API/appsettings.json
+++ b/src/Customer/GoingGreen.Customer.API/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "Postgres": "Host=localhost;Database=goinggreen;Username=postgres;Password=postgres",
+    "ServiceBus": "Endpoint=sb://your-servicebus.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=changeme"
+  },
   "AllowedHosts": "*"
 }

--- a/src/DeviceRegistry/GoingGreen.DeviceRegistry.API/Eventing/EventingExtensions.cs
+++ b/src/DeviceRegistry/GoingGreen.DeviceRegistry.API/Eventing/EventingExtensions.cs
@@ -1,0 +1,52 @@
+using Azure.Messaging.ServiceBus;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace DeviceRegistry.API;
+
+public static class EventingExtensions
+{
+    public static IHostApplicationBuilder AddEventing(this IHostApplicationBuilder builder)
+    {
+        var configuration = builder.Configuration;
+        var pg = configuration.GetConnectionString("Postgres") ?? configuration["POSTGRES_CONNECTION_STRING"];
+        builder.Services.AddMarten(opts =>
+        {
+            opts.Connection(pg);
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.All);
+        }).UseLightweightSessions().UseEventStore();
+
+        var sb = configuration.GetConnectionString("ServiceBus") ?? configuration["SERVICEBUS_CONNECTION_STRING"];
+        if (!string.IsNullOrWhiteSpace(sb))
+        {
+            builder.Services.AddSingleton(new ServiceBusClient(sb));
+            builder.Services.AddSingleton<IEventPublisher, ServiceBusEventPublisher>();
+        }
+
+        return builder;
+    }
+}
+
+public interface IEventPublisher
+{
+    Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default);
+}
+
+public class ServiceBusEventPublisher : IEventPublisher
+{
+    private readonly ServiceBusClient _client;
+
+    public ServiceBusEventPublisher(ServiceBusClient client)
+    {
+        _client = client;
+    }
+
+    public async Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default)
+    {
+        var sender = _client.CreateSender(typeof(T).Name);
+        var body = System.Text.Json.JsonSerializer.Serialize(@event);
+        await sender.SendMessageAsync(new ServiceBusMessage(body), cancellationToken);
+    }
+}

--- a/src/DeviceRegistry/GoingGreen.DeviceRegistry.API/GoingGreen.DeviceRegistry.API.csproj
+++ b/src/DeviceRegistry/GoingGreen.DeviceRegistry.API/GoingGreen.DeviceRegistry.API.csproj
@@ -8,9 +8,11 @@
         <RootNamespace>DeviceRegistry.API</RootNamespace>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4"/>
-    </ItemGroup>
+  <ItemGroup>
+          <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+          <PackageReference Include="Marten" Version="7.5.0" />
+          <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
+  </ItemGroup>
 
     <ItemGroup>
       <Content Include="..\..\..\.dockerignore">

--- a/src/DeviceRegistry/GoingGreen.DeviceRegistry.API/Program.cs
+++ b/src/DeviceRegistry/GoingGreen.DeviceRegistry.API/Program.cs
@@ -1,7 +1,10 @@
+using DeviceRegistry.API;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
+builder.AddEventing();
 
 // Add services to the container.
 builder.Services.AddProblemDetails();

--- a/src/DeviceRegistry/GoingGreen.DeviceRegistry.API/appsettings.json
+++ b/src/DeviceRegistry/GoingGreen.DeviceRegistry.API/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "Postgres": "Host=localhost;Database=goinggreen;Username=postgres;Password=postgres",
+    "ServiceBus": "Endpoint=sb://your-servicebus.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=changeme"
+  },
   "AllowedHosts": "*"
 }

--- a/src/Payment/GoingGreen.Payment.API/Eventing/EventingExtensions.cs
+++ b/src/Payment/GoingGreen.Payment.API/Eventing/EventingExtensions.cs
@@ -1,0 +1,52 @@
+using Azure.Messaging.ServiceBus;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Payment.API;
+
+public static class EventingExtensions
+{
+    public static IHostApplicationBuilder AddEventing(this IHostApplicationBuilder builder)
+    {
+        var configuration = builder.Configuration;
+        var pg = configuration.GetConnectionString("Postgres") ?? configuration["POSTGRES_CONNECTION_STRING"];
+        builder.Services.AddMarten(opts =>
+        {
+            opts.Connection(pg);
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.All);
+        }).UseLightweightSessions().UseEventStore();
+
+        var sb = configuration.GetConnectionString("ServiceBus") ?? configuration["SERVICEBUS_CONNECTION_STRING"];
+        if (!string.IsNullOrWhiteSpace(sb))
+        {
+            builder.Services.AddSingleton(new ServiceBusClient(sb));
+            builder.Services.AddSingleton<IEventPublisher, ServiceBusEventPublisher>();
+        }
+
+        return builder;
+    }
+}
+
+public interface IEventPublisher
+{
+    Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default);
+}
+
+public class ServiceBusEventPublisher : IEventPublisher
+{
+    private readonly ServiceBusClient _client;
+
+    public ServiceBusEventPublisher(ServiceBusClient client)
+    {
+        _client = client;
+    }
+
+    public async Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default)
+    {
+        var sender = _client.CreateSender(typeof(T).Name);
+        var body = System.Text.Json.JsonSerializer.Serialize(@event);
+        await sender.SendMessageAsync(new ServiceBusMessage(body), cancellationToken);
+    }
+}

--- a/src/Payment/GoingGreen.Payment.API/Eventing/Events.cs
+++ b/src/Payment/GoingGreen.Payment.API/Eventing/Events.cs
@@ -1,0 +1,5 @@
+namespace Payment.API;
+
+public record CustomerAcceptedFinalQuote(Guid AssessmentId);
+public record PayoutInitiated(Guid PayoutId, Guid CustomerId, decimal Amount);
+public record PayoutCompleted(Guid PayoutId, string TransactionId);

--- a/src/Payment/GoingGreen.Payment.API/GoingGreen.Payment.API.csproj
+++ b/src/Payment/GoingGreen.Payment.API/GoingGreen.Payment.API.csproj
@@ -8,9 +8,11 @@
         <RootNamespace>Payment.API</RootNamespace>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4"/>
-    </ItemGroup>
+  <ItemGroup>
+          <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+          <PackageReference Include="Marten" Version="7.5.0" />
+          <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
+  </ItemGroup>
 
     <ItemGroup>
       <Content Include="..\..\..\.dockerignore">

--- a/src/Payment/GoingGreen.Payment.API/Program.cs
+++ b/src/Payment/GoingGreen.Payment.API/Program.cs
@@ -1,7 +1,10 @@
+using Payment.API;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
+builder.AddEventing();
 
 // Add services to the container.
 builder.Services.AddProblemDetails();

--- a/src/Payment/GoingGreen.Payment.API/appsettings.json
+++ b/src/Payment/GoingGreen.Payment.API/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "Postgres": "Host=localhost;Database=goinggreen;Username=postgres;Password=postgres",
+    "ServiceBus": "Endpoint=sb://your-servicebus.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=changeme"
+  },
   "AllowedHosts": "*"
 }

--- a/src/Quote/GoingGreen.Quote.API/Eventing/EventingExtensions.cs
+++ b/src/Quote/GoingGreen.Quote.API/Eventing/EventingExtensions.cs
@@ -1,0 +1,52 @@
+using Azure.Messaging.ServiceBus;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Quote.API;
+
+public static class EventingExtensions
+{
+    public static IHostApplicationBuilder AddEventing(this IHostApplicationBuilder builder)
+    {
+        var configuration = builder.Configuration;
+        var pg = configuration.GetConnectionString("Postgres") ?? configuration["POSTGRES_CONNECTION_STRING"];
+        builder.Services.AddMarten(opts =>
+        {
+            opts.Connection(pg);
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.All);
+        }).UseLightweightSessions().UseEventStore();
+
+        var sb = configuration.GetConnectionString("ServiceBus") ?? configuration["SERVICEBUS_CONNECTION_STRING"];
+        if (!string.IsNullOrWhiteSpace(sb))
+        {
+            builder.Services.AddSingleton(new ServiceBusClient(sb));
+            builder.Services.AddSingleton<IEventPublisher, ServiceBusEventPublisher>();
+        }
+
+        return builder;
+    }
+}
+
+public interface IEventPublisher
+{
+    Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default);
+}
+
+public class ServiceBusEventPublisher : IEventPublisher
+{
+    private readonly ServiceBusClient _client;
+
+    public ServiceBusEventPublisher(ServiceBusClient client)
+    {
+        _client = client;
+    }
+
+    public async Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default)
+    {
+        var sender = _client.CreateSender(typeof(T).Name);
+        var body = System.Text.Json.JsonSerializer.Serialize(@event);
+        await sender.SendMessageAsync(new ServiceBusMessage(body), cancellationToken);
+    }
+}

--- a/src/Quote/GoingGreen.Quote.API/Eventing/Events.cs
+++ b/src/Quote/GoingGreen.Quote.API/Eventing/Events.cs
@@ -1,0 +1,4 @@
+namespace Quote.API;
+
+public record QuoteRequested(Guid QuoteId, Guid DeviceId, decimal InitialValue, string CustomerInfo);
+public record QuoteProvided(Guid QuoteId, decimal EstimatedValue);

--- a/src/Quote/GoingGreen.Quote.API/GoingGreen.Quote.API.csproj
+++ b/src/Quote/GoingGreen.Quote.API/GoingGreen.Quote.API.csproj
@@ -8,9 +8,11 @@
         <RootNamespace>Quote.API</RootNamespace>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4"/>
-    </ItemGroup>
+  <ItemGroup>
+      <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+      <PackageReference Include="Marten" Version="7.5.0" />
+      <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
+  </ItemGroup>
 
     <ItemGroup>
       <Content Include="..\..\..\.dockerignore">

--- a/src/Quote/GoingGreen.Quote.API/Program.cs
+++ b/src/Quote/GoingGreen.Quote.API/Program.cs
@@ -1,7 +1,10 @@
+using Quote.API;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
+builder.AddEventing();
 
 // Add services to the container.
 builder.Services.AddProblemDetails();

--- a/src/Quote/GoingGreen.Quote.API/appsettings.json
+++ b/src/Quote/GoingGreen.Quote.API/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "Postgres": "Host=localhost;Database=goinggreen;Username=postgres;Password=postgres",
+    "ServiceBus": "Endpoint=sb://your-servicebus.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=changeme"
+  },
   "AllowedHosts": "*"
 }

--- a/src/Shipping/GoingGreen.Shipping.API/Eventing/EventingExtensions.cs
+++ b/src/Shipping/GoingGreen.Shipping.API/Eventing/EventingExtensions.cs
@@ -1,0 +1,52 @@
+using Azure.Messaging.ServiceBus;
+using Marten;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Shipping.API;
+
+public static class EventingExtensions
+{
+    public static IHostApplicationBuilder AddEventing(this IHostApplicationBuilder builder)
+    {
+        var configuration = builder.Configuration;
+        var pg = configuration.GetConnectionString("Postgres") ?? configuration["POSTGRES_CONNECTION_STRING"];
+        builder.Services.AddMarten(opts =>
+        {
+            opts.Connection(pg);
+            opts.AutoCreateSchemaObjects = AutoCreate.All;
+            opts.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.All);
+        }).UseLightweightSessions().UseEventStore();
+
+        var sb = configuration.GetConnectionString("ServiceBus") ?? configuration["SERVICEBUS_CONNECTION_STRING"];
+        if (!string.IsNullOrWhiteSpace(sb))
+        {
+            builder.Services.AddSingleton(new ServiceBusClient(sb));
+            builder.Services.AddSingleton<IEventPublisher, ServiceBusEventPublisher>();
+        }
+
+        return builder;
+    }
+}
+
+public interface IEventPublisher
+{
+    Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default);
+}
+
+public class ServiceBusEventPublisher : IEventPublisher
+{
+    private readonly ServiceBusClient _client;
+
+    public ServiceBusEventPublisher(ServiceBusClient client)
+    {
+        _client = client;
+    }
+
+    public async Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default)
+    {
+        var sender = _client.CreateSender(typeof(T).Name);
+        var body = System.Text.Json.JsonSerializer.Serialize(@event);
+        await sender.SendMessageAsync(new ServiceBusMessage(body), cancellationToken);
+    }
+}

--- a/src/Shipping/GoingGreen.Shipping.API/Eventing/Events.cs
+++ b/src/Shipping/GoingGreen.Shipping.API/Eventing/Events.cs
@@ -1,0 +1,5 @@
+namespace Shipping.API;
+
+public record QuoteAccepted(Guid QuoteId);
+public record ShippingLabelGenerated(Guid ShipmentId, string LabelUrl, string TrackingId);
+public record PackageShipped(Guid ShipmentId, DateTime ShippedAt);

--- a/src/Shipping/GoingGreen.Shipping.API/GoingGreen.Shipping.API.csproj
+++ b/src/Shipping/GoingGreen.Shipping.API/GoingGreen.Shipping.API.csproj
@@ -8,9 +8,11 @@
         <RootNamespace>Shipping.API</RootNamespace>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4"/>
-    </ItemGroup>
+  <ItemGroup>
+          <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+          <PackageReference Include="Marten" Version="7.5.0" />
+          <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
+  </ItemGroup>
 
     <ItemGroup>
       <Content Include="..\..\..\.dockerignore">

--- a/src/Shipping/GoingGreen.Shipping.API/Program.cs
+++ b/src/Shipping/GoingGreen.Shipping.API/Program.cs
@@ -1,7 +1,10 @@
+using Shipping.API;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
+builder.AddEventing();
 
 // Add services to the container.
 builder.Services.AddProblemDetails();

--- a/src/Shipping/GoingGreen.Shipping.API/appsettings.json
+++ b/src/Shipping/GoingGreen.Shipping.API/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "Postgres": "Host=localhost;Database=goinggreen;Username=postgres;Password=postgres",
+    "ServiceBus": "Endpoint=sb://your-servicebus.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=changeme"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- revert the shared eventing project
- add Marten and Service Bus setup inside each microservice
- define workflow events in each microservice domain
- register `AddEventing` extension in service startup
- include Postgres and Service Bus connection strings

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685323407d14832eaf1f9848d5bc3a69