### PR TITLE
Update Marten to v8

### DIFF
--- a/src/Customer/GoingGreen.Customer.API/Eventing/EventingExtensions.cs
+++ b/src/Customer/GoingGreen.Customer.API/Eventing/EventingExtensions.cs
@@ -1,5 +1,7 @@
 using Azure.Messaging.ServiceBus;
 using Marten;
+using Marten.Events;
+using Weasel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -16,7 +18,7 @@ public static class EventingExtensions
             opts.Connection(pg);
             opts.AutoCreateSchemaObjects = AutoCreate.All;
             opts.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.All);
-        }).UseLightweightSessions().UseEventStore();
+        }).UseLightweightSessions().UseEventing();
 
         var sb = configuration.GetConnectionString("ServiceBus") ?? configuration["SERVICEBUS_CONNECTION_STRING"];
         if (!string.IsNullOrWhiteSpace(sb))

--- a/src/Customer/GoingGreen.Customer.API/GoingGreen.Customer.API.csproj
+++ b/src/Customer/GoingGreen.Customer.API/GoingGreen.Customer.API.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
           <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
-          <PackageReference Include="Marten" Version="7.5.0" />
+          <PackageReference Include="Marten" Version="8.0.0" />
           <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
   </ItemGroup>
 

--- a/src/DeviceRegistry/GoingGreen.DeviceRegistry.API/Eventing/EventingExtensions.cs
+++ b/src/DeviceRegistry/GoingGreen.DeviceRegistry.API/Eventing/EventingExtensions.cs
@@ -1,5 +1,7 @@
 using Azure.Messaging.ServiceBus;
 using Marten;
+using Marten.Events;
+using Weasel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -16,7 +18,7 @@ public static class EventingExtensions
             opts.Connection(pg);
             opts.AutoCreateSchemaObjects = AutoCreate.All;
             opts.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.All);
-        }).UseLightweightSessions().UseEventStore();
+        }).UseLightweightSessions().UseEventing();
 
         var sb = configuration.GetConnectionString("ServiceBus") ?? configuration["SERVICEBUS_CONNECTION_STRING"];
         if (!string.IsNullOrWhiteSpace(sb))

--- a/src/DeviceRegistry/GoingGreen.DeviceRegistry.API/GoingGreen.DeviceRegistry.API.csproj
+++ b/src/DeviceRegistry/GoingGreen.DeviceRegistry.API/GoingGreen.DeviceRegistry.API.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
           <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
-          <PackageReference Include="Marten" Version="7.5.0" />
+          <PackageReference Include="Marten" Version="8.0.0" />
           <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
   </ItemGroup>
 

--- a/src/Payment/GoingGreen.Payment.API/Eventing/EventingExtensions.cs
+++ b/src/Payment/GoingGreen.Payment.API/Eventing/EventingExtensions.cs
@@ -1,5 +1,7 @@
 using Azure.Messaging.ServiceBus;
 using Marten;
+using Marten.Events;
+using Weasel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -16,7 +18,7 @@ public static class EventingExtensions
             opts.Connection(pg);
             opts.AutoCreateSchemaObjects = AutoCreate.All;
             opts.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.All);
-        }).UseLightweightSessions().UseEventStore();
+        }).UseLightweightSessions().UseEventing();
 
         var sb = configuration.GetConnectionString("ServiceBus") ?? configuration["SERVICEBUS_CONNECTION_STRING"];
         if (!string.IsNullOrWhiteSpace(sb))

--- a/src/Payment/GoingGreen.Payment.API/GoingGreen.Payment.API.csproj
+++ b/src/Payment/GoingGreen.Payment.API/GoingGreen.Payment.API.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
           <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
-          <PackageReference Include="Marten" Version="7.5.0" />
+          <PackageReference Include="Marten" Version="8.0.0" />
           <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
   </ItemGroup>
 

--- a/src/Quote/GoingGreen.Quote.API/Eventing/EventingExtensions.cs
+++ b/src/Quote/GoingGreen.Quote.API/Eventing/EventingExtensions.cs
@@ -1,5 +1,7 @@
 using Azure.Messaging.ServiceBus;
 using Marten;
+using Marten.Events;
+using Weasel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -16,7 +18,7 @@ public static class EventingExtensions
             opts.Connection(pg);
             opts.AutoCreateSchemaObjects = AutoCreate.All;
             opts.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.All);
-        }).UseLightweightSessions().UseEventStore();
+        }).UseLightweightSessions().UseEventing();
 
         var sb = configuration.GetConnectionString("ServiceBus") ?? configuration["SERVICEBUS_CONNECTION_STRING"];
         if (!string.IsNullOrWhiteSpace(sb))

--- a/src/Quote/GoingGreen.Quote.API/GoingGreen.Quote.API.csproj
+++ b/src/Quote/GoingGreen.Quote.API/GoingGreen.Quote.API.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
-      <PackageReference Include="Marten" Version="7.5.0" />
+      <PackageReference Include="Marten" Version="8.0.0" />
       <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
   </ItemGroup>
 

--- a/src/Shipping/GoingGreen.Shipping.API/Eventing/EventingExtensions.cs
+++ b/src/Shipping/GoingGreen.Shipping.API/Eventing/EventingExtensions.cs
@@ -1,5 +1,7 @@
 using Azure.Messaging.ServiceBus;
 using Marten;
+using Marten.Events;
+using Weasel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -16,7 +18,7 @@ public static class EventingExtensions
             opts.Connection(pg);
             opts.AutoCreateSchemaObjects = AutoCreate.All;
             opts.UseDefaultSerialization(nonPublicMembersStorage: NonPublicMembersStorage.All);
-        }).UseLightweightSessions().UseEventStore();
+        }).UseLightweightSessions().UseEventing();
 
         var sb = configuration.GetConnectionString("ServiceBus") ?? configuration["SERVICEBUS_CONNECTION_STRING"];
         if (!string.IsNullOrWhiteSpace(sb))

--- a/src/Shipping/GoingGreen.Shipping.API/GoingGreen.Shipping.API.csproj
+++ b/src/Shipping/GoingGreen.Shipping.API/GoingGreen.Shipping.API.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
           <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
-          <PackageReference Include="Marten" Version="7.5.0" />
+          <PackageReference Include="Marten" Version="8.0.0" />
           <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- update Marten dependency to v8
- adapt eventing extensions to the new `UseEventing` API
- add missing imports for `AutoCreate` and `UseEventing`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593b84e3b0832e9dd351949e423f4c